### PR TITLE
Fix participants count route

### DIFF
--- a/event-app-backend/src/routes/ParticipantRoutes.ts
+++ b/event-app-backend/src/routes/ParticipantRoutes.ts
@@ -11,8 +11,8 @@ import {
 const router = express.Router();
 
 router.get("/check", checkParticipation);
-router.get("/:id", getParticipantByEvent);
 router.get("/count/:eventId", countParticipantsByEvent);
+router.get("/:id", getParticipantByEvent);
 router.post("/", registerToEvent);
 router.delete("/:id", deleteParticipant);
 router.delete("/", unregisterFromEvent);


### PR DESCRIPTION
## Summary
- fix unreachable participants count route

## Testing
- `npm run build` (fails: cannot find module 'sequelize')
- `npm run build` in frontend (fails: JSX implicitly has type 'any')

------
https://chatgpt.com/codex/tasks/task_e_6879fe0c40b08326a0cb5117a3d8968c